### PR TITLE
fix: clear malformed heatmap cache entries

### DIFF
--- a/src/services/heatmapCache.ts
+++ b/src/services/heatmapCache.ts
@@ -103,8 +103,14 @@ function extractPriceBinConfig(data: HeatMapCell[][]): CachedHeatmapData['priceB
  * Returns null if no cache, expired, or schema mismatch
  */
 export function loadHeatmapFromCache(): CachedHeatmapData | null {
+  const rawCached = safeStorage.getItem(CACHE_KEY);
+  if (rawCached === null) return null;
+
   const cached = safeStorage.getJSON<CachedHeatmapData | null>(CACHE_KEY, null);
-  if (!cached) return null;
+  if (!cached) {
+    clearHeatmapCache();
+    return null;
+  }
 
   // Check schema version
   if (cached.version !== CACHE_VERSION) {


### PR DESCRIPTION
## Summary
- clear corrupted heatmap cache entries when the storage key exists but JSON parsing fails
- preserve the existing behavior for missing cache entries, version mismatches, and expired cache entries

## Why
`loadHeatmapFromCache()` already clears invalid cache state for schema mismatches and expiration, but malformed JSON currently remains in `localStorage`. That leaves the cache in a permanently corrupted state and keeps the existing unit test failing.

## Verification
- `npm run test:unit -- src/services/heatmapCache.test.ts`
- `npm run test:unit`

Closes #19
